### PR TITLE
Always set random seed and seed strategy for Dieharder tests.

### DIFF
--- a/rtt/batteries/dieharder/variant-dh.cpp
+++ b/rtt/batteries/dieharder/variant-dh.cpp
@@ -60,7 +60,9 @@ void Variant::buildStrings() {
     /* Specify binary file generator */
     arguments << "-g " << OPTION_FILE_GENERATOR << " ";
     /* Specify binary input file */
-    arguments << "-f " << binaryDataPath;
+    arguments << "-f " << binaryDataPath << " ";
+    /* Specify random seed and seed strategy */
+    arguments << "-S 0 -s 1 ";
     cliArguments = arguments.str();
 
     /* Building standard input */


### PR DESCRIPTION
We now use "-s 1 -S 0" additional options for all Dieharder tests.

According to man page and Dieharder code:
"-s strategy - if strategy is the (default) 0, dieharder reseeds (or rewinds) once at the beginning when the random number generator is selected and then never again."

This meas that any benchamrk can move pointer in input file and the analysis is not deterministic as we expect.

If we set "-s 1" then
"If strategy is nonzero, the generator is reseeded or rewound at the beginning of EACH TEST.
 If -S seed was specified, or a file is used, this means every test is applied to the same sequence
 (which is useful for validation and testing of dieharder, but not a good way to test rngs).
 Otherwise a new random seed is selected for each test."

what is desired behaviour here (if using pre-generated files).

But together with -s 1 we have to set also seed, the best is here just set "-S 0" that keeps the seed random (the note that it is ignored for files is not always true).