### PR TITLE
Fix double conversion

### DIFF
--- a/rtt/batteries/dieharder/testresult-dh.cpp
+++ b/rtt/batteries/dieharder/testresult-dh.cpp
@@ -14,7 +14,9 @@ std::unique_ptr<TestResult> TestResult::getInstance(
                                        tests.at(0)->getLogicName()));
 
     static const std::regex RE_PVALUE {
-        "\\+\\+\\+\\+([01]\\.[0-9]+?)\\+\\+\\+\\+\\n"
+// old regex, replaced with upstream version
+//      "\\+\\+\\+\\+([01]\\.[0-9]+?)\\+\\+\\+\\+\\n"
+        "\\|([01]\\.[0-9]+?)\\|\\n"
     };
     auto endIt = std::sregex_iterator();
 

--- a/rtt/batteries/dieharder/variant-dh.cpp
+++ b/rtt/batteries/dieharder/variant-dh.cpp
@@ -4,7 +4,7 @@ namespace rtt {
 namespace batteries {
 namespace dieharder {
 
-const int Variant::OPTION_HEADER_FLAG      = 66047;
+const int Variant::OPTION_HEADER_FLAG      = 197119; //66047;
 const int Variant::OPTION_FILE_GENERATOR   = 201;
 
 std::unique_ptr<Variant> Variant::getInstance(int testId, std::string testObjInf,

--- a/rtt/utils.cpp
+++ b/rtt/utils.cpp
@@ -49,7 +49,7 @@ double Utils::strtod(const std::string & str) {
                                  "string contain invalid characters");
     }
     try {
-        float result = std::stod(str);
+        double result = std::stod(str);
         return result;
     } catch (std::out_of_range) {
         /* invalid_argument won't be thrown, regex prevents that */


### PR DESCRIPTION
 Fix a double conversion util to not lost precision.
    
Apparently copy&paste bug where a float temp variable was used.
    
 So it means all p-values until today were processed as floats 8-)

