### PR TITLE
Support input from file with space in name.

### DIFF
--- a/rtt/batteries/dieharder/variant-dh.cpp
+++ b/rtt/batteries/dieharder/variant-dh.cpp
@@ -60,7 +60,7 @@ void Variant::buildStrings() {
     /* Specify binary file generator */
     arguments << "-g " << OPTION_FILE_GENERATOR << " ";
     /* Specify binary input file */
-    arguments << "-f " << binaryDataPath << " ";
+    arguments << "-f \"" << binaryDataPath << "\" ";
     /* Specify random seed and seed strategy */
     arguments << "-S 0 -s 1 ";
     cliArguments = arguments.str();

--- a/rtt/batteries/niststs/variant-sts.cpp
+++ b/rtt/batteries/niststs/variant-sts.cpp
@@ -71,18 +71,14 @@ void Variant::buildStrings() {
     /* Building cli arguments */
     std::stringstream arguments;
     /* -fast is used with faster version of NIST STS */
-    //arguments << "assess " << streamSize << " -fast";
     arguments << "niststs " << streamSize << " -fast";
+    arguments << " --file \"" << binaryDataPath << "\"";
     cliArguments = arguments.str();
 
     /* Building standard input */
     /* 'Beautiful' creation of input that will be sent to */
     /* sts over pipe, so that it will have proper settings. */
     std::stringstream stdIn;
-    /* Choosing input file generator */
-    stdIn << "0 ";
-    /* Choosing file */
-    stdIn << binaryDataPath << " ";
     /* Execute only one test */
     stdIn << "0 ";
     /* Specify which test will be executed */

--- a/rtt/batteries/testrunner-batt.cpp
+++ b/rtt/batteries/testrunner-batt.cpp
@@ -353,7 +353,7 @@ void TestRunner::readOutput(BatteryOutput & output ,
 }
 
 char ** TestRunner::buildArgv(const std::string & arguments, int * argc) {
-    std::vector<std::string> vecArg = Utils::split(arguments , ' ');
+    std::vector<std::string> vecArg = Utils::splitarg(arguments , ' ');
     char ** argv = new char * [vecArg.size() + 1];
     for(size_t i = 0 ; i < vecArg.size() ; ++i) {
         argv[i] = new char [vecArg.at(i).length() + 1];

--- a/rtt/batteries/testu01/variant-tu01.cpp
+++ b/rtt/batteries/testu01/variant-tu01.cpp
@@ -109,7 +109,7 @@ void Variant::buildStrings() {
     /* Test number option */
     arguments << "-t " << testId << " ";
     /* Input file option */
-    arguments << "-i " << binaryDataPath << " ";
+    arguments << "-i \"" << binaryDataPath << "\" ";
     /* Repetitions option */
     if(repetitions != 1)
         arguments << "-r " << repetitions << " ";

--- a/rtt/clinterface/clargument.h
+++ b/rtt/clinterface/clargument.h
@@ -109,11 +109,40 @@ ArgumentType ClArgument<ArgumentType>::getArgumentValue() const {
     }
 }
 
+template<typename T>
+static T lexical_cast(const std::string & str) {
+    T rval;
+    std::istringstream iss;
+    iss.str(str);
+
+    iss >> rval;
+
+    if(!iss.eof() || iss.fail())
+        throw std::runtime_error("can't convert \"" + str + "\"");
+
+    return rval;
+}
+
+template<>
+std::string lexical_cast(const std::string & str) {
+    std::string  rval;
+    std::istringstream iss;
+    iss.str(str);
+
+    // for string, do not stop at the first whitespace
+    std::getline(iss, rval);
+
+    if(!iss.eof() || iss.fail())
+        throw std::runtime_error("can't convert \"" + str + "\"");
+
+    return rval;
+}
+
 template<typename ArgumentType>
 void ClArgument<ArgumentType>::setArgumentValue(const std::string & argValue) {
     if(!set) {
         try {
-            argumentValue = Utils::lexical_cast<ArgumentType>(argValue);
+            argumentValue = lexical_cast<ArgumentType>(argValue);
             set = true;
         } catch (std::runtime_error & e) {
             throw RTTException(objectInfo, e.what());

--- a/rtt/utils.cpp
+++ b/rtt/utils.cpp
@@ -129,6 +129,25 @@ std::vector<std::string> Utils::split(const std::string & toSplit , char separat
     return result;
 }
 
+std::vector<std::string> Utils::splitarg(const std::string & toSplit , char separator) {
+    std::vector<std::string> result;
+    std::string temp;
+    bool in_string = false;
+
+    for(size_t i = 0 ; i < toSplit.length() ; i++) {
+        if (toSplit[i] == '"') {
+            in_string = !in_string;
+        } else if(toSplit[i] != separator || in_string) {
+            temp.push_back(toSplit[i]);
+        } else {
+            if(temp.length() > 0) result.push_back(temp);
+            temp.clear();
+        }
+    }
+    if(temp.length() > 0) result.push_back(temp);
+    return result;
+}
+
 void Utils::fixNewlines(std::string & str) {
     std::string::size_type pos = 0;
     while ((pos = str.find("\r\n", pos)) != std::string::npos) {

--- a/rtt/utils.h
+++ b/rtt/utils.h
@@ -110,6 +110,12 @@ public:
       */
     static std::vector<std::string> split(const std::string & toSplit , char separator);
 
+    /** Splits string into shorter strings, separated by separator, support string in quotes
+      * @param                 toSplit string to be splitted
+      * @return                vector of strings
+      */
+    static std::vector<std::string> splitarg(const std::string & toSplit, char separator);
+
     /** Replaces all Windows newlines (\r\n) with Unix newlines (\n).
       * Sometimes Unix system will read \r\n instead of \n from file.
       * Input text files that will be modified (such as script samples)
@@ -174,19 +180,6 @@ public:
         std::vector<T *> rval(source.size());
         std::transform(source.begin(), source.end(), rval.begin(),
                        [](const auto & el){ return el.get(); });
-        return rval;
-    }
-
-    template<typename T>
-    static T lexical_cast(const std::string & str) {
-        T rval;
-        std::istringstream iss;
-        iss.str(str);
-
-        iss >> rval;
-        if(!iss.eof() || iss.fail())
-            throw std::runtime_error("can't convert \"" + str + "\"");
-
         return rval;
     }
 


### PR DESCRIPTION
File is not always used with quotation marks for batteries commandline.

There are still some not working file names, but let's ignore it for now, the code is already overengineered enough.

Fixes: #50