### PR TITLE
Speedup output regex parsing.

### DIFF
--- a/rtt/batteries/batteryoutput.cpp
+++ b/rtt/batteries/batteryoutput.cpp
@@ -3,8 +3,8 @@
 namespace rtt {
 namespace batteries {
 
-static const std::regex RE_ERR ("\\s*(.*?error.*?)\\n", std::regex::icase);
-static const std::regex RE_WARN ("\\s*(.*?warning.*?)\\n", std::regex::icase);
+static const std::regex RE_ERR ("\\n\\s*(.*?error.*?)\\n", std::regex::icase);
+static const std::regex RE_WARN ("\\n\\s*(.*?warning.*?)\\n", std::regex::icase);
 
 void BatteryOutput::appendStdOut(const std::string & stdOut) {
     detectionDone = false;


### PR DESCRIPTION
The current regex produces a lot of backtracking, limit it by EOL character (there is always some header before parsed output, so the output should be the same except whitespaces).