### PR TITLE
Avoid trimming Dieharder pvalues > 100000.

### DIFF
--- a/rtt/batteries/dieharder/variant-dh.cpp
+++ b/rtt/batteries/dieharder/variant-dh.cpp
@@ -53,6 +53,8 @@ void Variant::buildStrings() {
     }
     /* Set psample count */
     arguments << "-p " << pSampleCount << " ";
+    /* Set also Xoff to avoid trimming p-values count */
+    arguments << "-P " << pSampleCount << " ";
     /* Specify test */
     arguments << "-d " << testId << " ";
     /* Specify header flag */


### PR DESCRIPTION
We need to set also Xoff (-P) Dieharder parameter otherwise pvalues are trimmed if above this setting (default 100000).