### PR TITLE
Make mysql backed optional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,21 @@
 TOOL=randomness-testing-toolkit
 
+# Comment this out to disable MySQL backend
+USE_MYSQL_BACKEND=1
+
 CC=gcc
 CXX=g++
+CXXFLAGS += -std=c++14 -I. -O3 -g
+LIBS=-L/usr/lib -L. -lpthread
 
-ifndef LINK_PTHREAD
-override LINK_PTHREAD = -lpthread
+ifdef USE_MYSQL_BACKEND
+CXXFLAGS += -DUSE_MYSQL_BACKEND
+LIBS += -lmysqlcppconn
+STATIC_LIBS += -lmariadb
 endif
-
-ifndef LINK_MYSQL
-override LINK_MYSQL = -lmysqlcppconn
-endif
-
-LIBS=-L/usr/lib -L. $(LINK_MYSQL) $(LINK_PTHREAD)
 
 # Debian only fixed config for now
-STATIC_LIBS=-lmariadb -lssl -lcrypto -lz -static
-
-CXXFLAGS += -std=c++14 -I. -O3 -g
+STATIC_LIBS += -lssl -lcrypto -lz -static
 
 # === Header files ===
 # === Source files must be in same dir as corresponding header ===

--- a/rtt/storage/istorage.cpp
+++ b/rtt/storage/istorage.cpp
@@ -10,19 +10,13 @@ std::unique_ptr<IStorage> IStorage::getInstance(const GlobalContainer & containe
     switch(container.getRttCliOptions()->getResultStorageId()) {
     case Constants::ResultStorageID::FILE_REPORT:
         return FileStorage::getInstance(container);
+#ifdef USE_MYSQL_BACKEND
     case Constants::ResultStorageID::DB_MYSQL:
         return MySQLStorage::getInstance(container);
+#endif
     default:
         raiseBugException("invalid result storage id");
     }
-
-
-    /*if(container.getCliOptions()->getMysqlEid() != 0) {
-        return MySQLStorage::getInstance(container);
-    } else {
-        return FileStorage::getInstance(container);
-    }*/
-    //return FileStorage::getInstance(container);
 }
 
 } // namespace storage

--- a/rtt/storage/mysqlstorage.cpp
+++ b/rtt/storage/mysqlstorage.cpp
@@ -1,5 +1,6 @@
 #include "mysqlstorage.h"
 
+#ifdef USE_MYSQL_BACKEND
 namespace rtt {
 namespace storage {
 
@@ -662,3 +663,5 @@ void MySQLStorage::checkStorage() {
 
 } // namespace storage
 } // namespace rtt
+
+#endif // USE_MYSQL_BACKEND

--- a/rtt/storage/mysqlstorage.h
+++ b/rtt/storage/mysqlstorage.h
@@ -1,6 +1,8 @@
 #ifndef RTT_STORAGE_MYSQLSTORAGE_H
 #define RTT_STORAGE_MYSQLSTORAGE_H
 
+#ifdef USE_MYSQL_BACKEND
+
 #include <memory>
 #include <cstdint>
 #include <cppconn/driver.h>
@@ -119,5 +121,7 @@ private:
 
 } // namespace storage
 } // namespace rtt
+
+#endif // USE_MYSQL_BACKEND
 
 #endif // RTT_STORAGE_MYSQLSTORAGE_H


### PR DESCRIPTION
Some distros like Fedora have no longer needed packages for MySQL connection. As most people do not use it anyway, this patch allows to compile RTT without SQL backend just by commenting out line in Makefile.