### PR TITLE
Switch to boost regex (except for NIST).

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ USE_MYSQL_BACKEND=1
 CC=gcc
 CXX=g++
 CXXFLAGS += -std=c++14 -I. -O3 -g
-LIBS=-L/usr/lib -L. -lpthread
+LIBS=-L/usr/lib -L. -lpthread -lboost_regex
 
 ifdef USE_MYSQL_BACKEND
 CXXFLAGS += -DUSE_MYSQL_BACKEND

--- a/rtt/batteries/batteryoutput.cpp
+++ b/rtt/batteries/batteryoutput.cpp
@@ -3,8 +3,8 @@
 namespace rtt {
 namespace batteries {
 
-static const std::regex RE_ERR ("\\n\\s*(.*?error.*?)\\n", std::regex::icase);
-static const std::regex RE_WARN ("\\n\\s*(.*?warning.*?)\\n", std::regex::icase);
+static const boost::regex RE_ERR  ("\\n\\s*([^\\n]*error[^\\n]*)\\n", boost::regex::icase);
+static const boost::regex RE_WARN ("\\n\\s*([^\\n]*warning[^\\n]*)\\n", boost::regex::icase);
 
 void BatteryOutput::appendStdOut(const std::string & stdOut) {
     detectionDone = false;
@@ -44,10 +44,10 @@ void BatteryOutput::detectErrsWarnsInStdOut() {
      * Detection happens only in stdOut variable. */
 
 
-    std::smatch match;
-    auto end =       std::sregex_iterator();
-    auto errBegin =  std::sregex_iterator(stdOut.begin() , stdOut.end(), RE_ERR);
-    auto warnBegin = std::sregex_iterator(stdOut.begin() , stdOut.end(), RE_WARN);
+    boost::smatch match;
+    auto end =       boost::sregex_iterator();
+    auto errBegin =  boost::sregex_iterator(stdOut.begin() , stdOut.end(), RE_ERR);
+    auto warnBegin = boost::sregex_iterator(stdOut.begin() , stdOut.end(), RE_WARN);
 
     errors.clear();
     warnings.clear();

--- a/rtt/batteries/batteryoutput.h
+++ b/rtt/batteries/batteryoutput.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <vector>
-#include <regex>
+#include <boost/regex.hpp>
 
 namespace rtt {
 namespace batteries {

--- a/rtt/batteries/dieharder/testresult-dh.cpp
+++ b/rtt/batteries/dieharder/testresult-dh.cpp
@@ -13,12 +13,12 @@ std::unique_ptr<TestResult> TestResult::getInstance(
                                        tests.at(0)->getLogger(),
                                        tests.at(0)->getLogicName()));
 
-    static const std::regex RE_PVALUE {
+    static const boost::regex RE_PVALUE {
 // old regex, replaced with upstream version
 //      "\\+\\+\\+\\+([01]\\.[0-9]+?)\\+\\+\\+\\+\\n"
         "\\|([01]\\.[0-9]+?)\\|\\n"
     };
-    auto endIt = std::sregex_iterator();
+    auto endIt = boost::sregex_iterator();
 
     std::vector<result::SubTestResult> tmpSubTestResults;
     std::vector<result::Statistic> tmpStatistics;
@@ -40,7 +40,7 @@ std::unique_ptr<TestResult> TestResult::getInstance(
 
             /* Single subtest processing! */
             for(const std::string & subTest : subTests) {
-                auto pValIt = std::sregex_iterator(
+                auto pValIt = boost::sregex_iterator(
                                   subTest.begin(), subTest.end(),
                                   RE_PVALUE);
                 if(std::distance(pValIt, endIt) == 0) {
@@ -51,7 +51,7 @@ std::unique_ptr<TestResult> TestResult::getInstance(
 
                 /* Single pvalue processing */
                 for( ; pValIt != endIt ; ++pValIt) {
-                    std::smatch pvalMatch = *pValIt;
+                    boost::smatch pvalMatch = *pValIt;
                     tmpPVals.push_back(Utils::strtod(pvalMatch[1].str()));
                 }
                 tmpStatistics.push_back(result::Statistic::getInstance(

--- a/rtt/batteries/niststs/testresult-sts.cpp
+++ b/rtt/batteries/niststs/testresult-sts.cpp
@@ -2,6 +2,9 @@
 
 #include "libs/cephes/cephes.h"
 
+//FIXME: regex need to be converted to std::regex; they are not directly compatible
+#include <regex>
+
 namespace rtt {
 namespace batteries {
 namespace niststs {

--- a/rtt/batteries/testu01/testresult-tu01.h
+++ b/rtt/batteries/testu01/testresult-tu01.h
@@ -21,7 +21,7 @@ private:
         : ITestResult(logger , testName)
     {}
 
-    static std::regex buildParamRegex(
+    static boost::regex buildParamRegex(
             std::vector<std::string> paramNames);
 
     static double convertStringToDouble(const std::string & num,

--- a/rtt/utils.cpp
+++ b/rtt/utils.cpp
@@ -10,11 +10,11 @@ std::string Utils::itostr(int i , int width) {
     return ss.str();
 }
 
-static const std::regex RE_INTEGER("^-?[0-9]+?$");
-static const std::regex RE_FLOAT("^-?[0-9]+?(:?\\.[0-9]+?)?$");
+static const boost::regex RE_INTEGER("^-?[0-9]+?$");
+static const boost::regex RE_FLOAT("^-?[0-9]+?(:?\\.[0-9]+?)?$");
 
 int Utils::strtoi(const std::string & str) {
-    if(!std::regex_match(str.begin() , str.end() , RE_INTEGER)) {
+    if(!boost::regex_match(str.begin() , str.end() , RE_INTEGER)) {
         throw std::runtime_error("can't convert string \"" + str +"\" into integer: " +
                                  "string contains invalid characters");
     }
@@ -29,7 +29,7 @@ int Utils::strtoi(const std::string & str) {
 }
 
 float Utils::strtof(const std::string & str) {
-    if(!std::regex_match(str.begin() , str.end() , RE_FLOAT)) {
+    if(!boost::regex_match(str.begin() , str.end() , RE_FLOAT)) {
         throw std::runtime_error("can't convert string \"" + str + "\" into float: " +
                                  "string contain invalid characters");
     }
@@ -44,7 +44,7 @@ float Utils::strtof(const std::string & str) {
 }
 
 double Utils::strtod(const std::string & str) {
-    if(!std::regex_match(str.begin() , str.end() , RE_FLOAT)) {
+    if(!boost::regex_match(str.begin() , str.end() , RE_FLOAT)) {
         throw std::runtime_error("can't convert string \"" + str + "\" into double: " +
                                  "string contain invalid characters");
     }

--- a/rtt/utils.h
+++ b/rtt/utils.h
@@ -8,7 +8,7 @@
 #include <stdexcept>
 #include <ctime>
 #include <vector>
-#include <regex>
+#include <boost/regex.hpp>
 #include <iostream>
 #include <dirent.h>
 #include <sys/types.h>


### PR DESCRIPTION
The C++ regex segfaults due to recursive stack use.

The boost regex seems to be much better, it works
with many repetitions in TestU01 too.

Note: NIST-STS still uses C++ regex, it need more investigation why it is not compatible.